### PR TITLE
Implement all split methods with split_pos

### DIFF
--- a/src/fortran202x_split.f90
+++ b/src/fortran202x_split.f90
@@ -57,7 +57,7 @@ contains
     if (slen > 0) then
       p = 0
       do while(p < slen)
-        n = n+1
+        n = n + 1
         istart(n) = min(p + 1, slen)
         call split(string, set, p)
         iend(n) = p - 1

--- a/src/fortran202x_split.f90
+++ b/src/fortran202x_split.f90
@@ -48,41 +48,24 @@ contains
     integer, allocatable, intent(out) :: first(:)
     integer, allocatable, intent(out) :: last(:)
 
-    character :: set_array(len(set))
-    logical, dimension(len(string)) :: is_first, is_last, is_separator
-    integer :: n, slen
+    integer, dimension(len(string)+1) :: istart, iend
+    integer :: p, n, slen
 
     slen = len(string)
 
-    do concurrent (n = 1:len(set))
-      set_array(n) = set(n:n)
-    end do
+    n = 0
+    if (slen > 0) then
+      p = 0
+      do while(p < slen)
+        n = n+1
+        istart(n) = min(p + 1, slen)
+        call split(string, set, p)
+        iend(n) = p - 1
+      end do
+    end if
 
-    do concurrent (n = 1:slen)
-      is_separator(n) = any(string(n:n) == set_array)
-    end do
-
-    is_first = .false.
-    is_last = .false.
-
-    if (.not. is_separator(1)) is_first(1) = .true.
-
-    do concurrent (n = 2:slen-1)
-      if (.not. is_separator(n)) then
-        if (is_separator(n - 1)) is_first(n) = .true.
-        if (is_separator(n + 1)) is_last(n) = .true.
-      else
-        if (is_separator(n - 1)) then
-          is_first(n) = .true.
-          is_last(n-1) = .true.
-        end if
-      end if
-    end do
-
-    if (.not. is_separator(slen)) is_last(slen) = .true.
-
-    first = pack([(n, n = 1, slen)], is_first)
-    last = pack([(n, n = 1, slen)], is_last)
+    first = istart(:n)
+    last = iend(:n)
 
   end subroutine split_first_last
 
@@ -98,7 +81,12 @@ contains
     logical, intent(in), optional :: back
 
     logical :: backward
-    integer :: result_pos
+    integer :: result_pos, bound
+
+    if (len(string) == 0) then
+      pos = 1
+      return
+    end if
 
     !TODO use optval when implemented in stdlib
     !backward = optval(back, .false.)
@@ -106,7 +94,8 @@ contains
     if (present(back)) backward = back
 
     if (backward) then
-      result_pos = scan(string(:max(pos-1, 1)), set, back=.true.)
+      bound = min(len(string), max(pos-1, 0))
+      result_pos = scan(string(:bound), set, back=.true.)
     else
       result_pos = scan(string(min(pos+1, len(string)):), set) + pos
       if (result_pos < pos+1) result_pos = len(string) + 1

--- a/test/main.f90
+++ b/test/main.f90
@@ -23,8 +23,8 @@ program test_split
   end do
 
   print *
-  print *, 'Example 2:'
   string = 'first,second,,forth'
+  print *, 'Example 2: "', string, '"'
   set = ',;'
   call split(string, set, first, last)
   print *, 'first =', first
@@ -51,7 +51,7 @@ program test_split
 
   do
     if (p <= 0) exit
-    iend = p - 1
+    iend = min(p - 1, len(string))
     call split(string, set, p, back=.true.)
     istart = p + 1
     print '(t7, a)', string(istart:iend)
@@ -59,5 +59,21 @@ program test_split
 
   ! Try to go out-of-bounds
   call split(string, set, p, back=.true.)
+
+  print *
+  string = ',;,;,;,;,'
+  print *, 'Example 4: "', string, '"'
+  set = ',;'
+  call split(string, set, first, last)
+  print *, 'first =', first
+  print *, 'last =', last
+
+  print *
+  string = ''
+  print *, 'Example 5: "', string, '"'
+  set = ',;'
+  call split(string, set, first, last)
+  print *, 'size(first) =', size(first)
+  print *, 'size(last) =', size(last)
 
 end program test_split


### PR DESCRIPTION
- implement all split functionality based on `split_pos`
- fix out of bounds errors in `split_pos`, this should also address most of the issues in #2

Using the benchmark in `fpm run` the implementation with `split_pos` is even faster than the previous `do concurrent` implementation:

```patch
+split subroutine, elapsed seconds:       mean =   0.117917798     std =    7.47864426E-04
-split subroutine, elapsed seconds:       mean =   0.157324597     std =    2.29698624E-02
+string_tokens function, elapsed seconds: mean =   0.173243582     std =    7.10971013E-04
-string_tokens function, elapsed seconds: mean =   0.204198599     std =    5.16618369E-04
```

Should also fix #2 