### PR TITLE
Improve bench formatting and reporting

### DIFF
--- a/app/main.f90
+++ b/app/main.f90
@@ -22,27 +22,32 @@ program bench
   end do
   1 close(u)
 
+  print *, 'Running split subroutine...'
   elapsed = [real ::]
-  do n = 1, 5
+  do n = 1, 10
     call cpu_time(t1)
     call split(string, ' ', tokens)
     call cpu_time(t2)
+    print '(a,i2,a,f9.7,a)', '  Run ', n, ': ', t2 - t1, ' seconds elapsed'
     elapsed = [elapsed, t2 - t1]
     deallocate(tokens)
   end do
-  print *, 'split subroutine, elapsed seconds:       ', &
-           'mean = ', mean(elapsed), 'std = ', std(elapsed)
+  print '(80("-"))'
+  print '(2(a,f9.7))', 'split subroutine, seconds elapsed: ', mean(elapsed), ' +/- ', std(elapsed)
 
+  print *
+  print *, 'Running string_tokens function...'
   elapsed = [real ::]
-  do n = 1, 5
+  do n = 1, 10
     call cpu_time(t1)
     tokens = string_tokens(string, ' ')
     call cpu_time(t2)
+    print '(a,i2,a,f9.7,a)', '  Run ', n, ': ', t2 - t1, ' seconds elapsed'
     elapsed = [elapsed, t2 - t1]
     deallocate(tokens)
   end do
-  print *, 'string_tokens function, elapsed seconds: ', &
-           'mean = ', mean(elapsed), 'std = ', std(elapsed)
+  print '(80("-"))'
+  print '(2(a,f9.7))', 'string_tokens function, seconds elapsed: ', mean(elapsed), ' +/- ', std(elapsed)
 
 contains
 


### PR DESCRIPTION
After the last monthly call I realized that the compiler optimizes subsequent runs of the `split` subroutine, I assume by not deallocating the array in between the calls and preserving the reserved space. Such optimization doesn't seem to be made with the `string_tokens` function. Because the bench reporting was only a mean +/- std of the 5 runs, this detail was hidden.

To make this transparent I now make each run report the elapsed seconds, before summarizing the mean +/- std at the end. I also tidied up the formatting and increased the number of runs to 10, as they're rather quick. The output now looks similar to:

```
 Running split subroutine...
  Run  1: 0.3680990 seconds elapsed
  Run  2: 0.2825310 seconds elapsed
  Run  3: 0.2613840 seconds elapsed
  Run  4: 0.2593930 seconds elapsed
  Run  5: 0.2593150 seconds elapsed
  Run  6: 0.2601440 seconds elapsed
  Run  7: 0.2594142 seconds elapsed
  Run  8: 0.2594762 seconds elapsed
  Run  9: 0.2591679 seconds elapsed
  Run 10: 0.2599461 seconds elapsed
--------------------------------------------------------------------------------
split subroutine, seconds elapsed: 0.2728871 +/- 0.0324598

 Running string_tokens function...
  Run  1: 0.3131039 seconds elapsed
  Run  2: 0.3122170 seconds elapsed
  Run  3: 0.3137522 seconds elapsed
  Run  4: 0.3169289 seconds elapsed
  Run  5: 0.3125043 seconds elapsed
  Run  6: 0.3131638 seconds elapsed
  Run  7: 0.3134732 seconds elapsed
  Run  8: 0.3126659 seconds elapsed
  Run  9: 0.3122683 seconds elapsed
  Run 10: 0.3146567 seconds elapsed
--------------------------------------------------------------------------------
string_tokens function, seconds elapsed: 0.3134734 +/- 0.0013518
```