### PR TITLE
Bump fpm-setup version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         --slave /usr/bin/gcov gcov /usr/bin/gcov-${GCC_V}
 
     - name: Install fpm
-      uses: fortran-lang/setup-fpm@v2
+      uses: fortran-lang/setup-fpm@v3
       with:
         fpm-version: 'v0.1.2'
 


### PR DESCRIPTION
Related to the renaming of the release artifacts with https://github.com/fortran-lang/fpm/pull/285, requires update of setup-fpm action after https://github.com/fortran-lang/setup-fpm/pull/2.